### PR TITLE
Enable wikilinks in tables

### DIFF
--- a/src/wikilink.js
+++ b/src/wikilink.js
@@ -14,7 +14,9 @@ function plugin(hook, vm) {
     const list = []
     list.push(...mdDom.getElementsByTagName('p'))
     list.push(...mdDom.getElementsByTagName('li'))
-
+    list.push(...mdDom.getElementsByTagName('td'))
+    list.push(...mdDom.getElementsByTagName('th'))
+    
     for (var i=0; i < list.length; i++) {
       var para = list[i].innerHTML
       const eachParaRes = para.replace(/\[\[([^\[\]]+)\]\]/g, function (content) {


### PR DESCRIPTION
I wanted to create wikilinks within tables like below and needed to add in at least `td` elements.

```md
|                   Command | Purpose                                        |                   Alternative                    |
| -------------------------:|:---------------------------------------------- |:------------------------------------------------:|
|                `[[chop]]` | **select** columns                             |               `cut` or `zeek-cut`                |
|                    `cols` |                                                |                                                  |
|        `[[conn-summary]]` | displays **connection summary** given Zeek logs|                `trace-summary`                   |
```